### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "type": "git",
     "url": "https://github.com/o0shojo0o/ioBroker.zigbee2mqtt.git"
   },
+  "engines": {
+    "node": ">= 16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3",
     "aedes": "^0.50.0",


### PR DESCRIPTION
adapter-core 3.x.x is known to fail when installed with node 14 due to npm 6 not installing peerDependencies. So this adapter requires node 16 or newer.