### PR TITLE
process actions after non-actions

### DIFF
--- a/lib/statesController.js
+++ b/lib/statesController.js
@@ -51,6 +51,8 @@ class StatesController {
                 continue;
             }
 
+            let actionStates = [];
+
             for (const state of states) {
 
                 const stateName = `${device.ieee_address}.${state.id}`;
@@ -62,19 +64,9 @@ class StatesController {
                 }
 
                 try {
-                    //  Is an action
+                    //  process actions after non-actions
                     if (state.prop && state.prop == 'action') {
-                        if (state.isEvent && state.isEvent == true) {
-                            if (state.type == 'boolean') {
-                                await this.setStateWithTimeoutAsync(stateName, state.getter(messageObj.payload), 450);
-                            }
-                            else {
-                                await this.setStateSafelyAsync(stateName, state.getter(messageObj.payload));
-                            }
-                        }
-                        else {
-                            await this.setStateChangedSafelyAsync(stateName, state.getter(messageObj.payload));
-                        }
+                        actionStates.push(state);
                     }
                     // Is not an action
                     else {
@@ -83,6 +75,28 @@ class StatesController {
                         } else {
                             await this.setStateChangedSafelyAsync(stateName, value);
                         }
+                    }
+                } catch (err) {
+                    incStatsQueue[incStatsQueue.length] = messageObj;
+                    this.adapter.log.debug(`Can not set ${stateName}, queue state in incStatsQueue!`);
+                }
+            }
+
+            for (const state of actionStates) {
+
+                const stateName = `${device.ieee_address}.${state.id}`;
+
+                try {
+                    if (state.isEvent && state.isEvent == true) {
+                        if (state.type == 'boolean') {
+                            await this.setStateWithTimeoutAsync(stateName, state.getter(messageObj.payload), 450);
+                        }
+                        else {
+                            await this.setStateSafelyAsync(stateName, state.getter(messageObj.payload));
+                        }
+                    }
+                    else {
+                        await this.setStateChangedSafelyAsync(stateName, state.getter(messageObj.payload));
                     }
                 } catch (err) {
                     incStatsQueue[incStatsQueue.length] = messageObj;


### PR DESCRIPTION
fixes #303 
In order to keep a message consistent, side data like action_group has to be set before an action. At the time a trigger is fired on an action the other data has to be already set. In case of #303 you have to know what action_group an action does belong to.