### PR TITLE
Enable occupancy update every time a message arrives

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -216,6 +216,17 @@
 			"type": "checkbox",
 			"label": "Download device images from Zigbee2Mqtt and use them as object icons.",
 			"newLine": true
+		},
+		"expertHeader": {
+			"type": "header",
+			"label": "Expert Settings. Please only use if you know what you're doing",
+			"size": 2,
+			"newLine": true
+		},
+		"allwaysUpdateOccupancyState": {
+			"type": "checkbox",
+			"label": "Allways update state for occupancy when message arrives from zigbee2mqtt server (Only for true state). Increases load on ioBroker System",
+			"newLine": true
 		}
 	}
 }

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -219,7 +219,7 @@
 		},
 		"expertHeader": {
 			"type": "header",
-			"label": "Expert Settings. Please only use if you know what you're doing",
+			"text": "Expert Settings. Please only use if you know what you're doing",
 			"size": 2,
 			"newLine": true
 		},

--- a/io-package.json
+++ b/io-package.json
@@ -248,7 +248,8 @@
         "brightnessMoveOnOff": false,
         "brightnessStepOnOff": false,
         "useEventInDesc": true,
-        "useDeviceIcons": false
+        "useDeviceIcons": false,
+        "allwaysUpdateOccupancyState": false
     },
     "protectedNative": [
         "externalMqttServerPassword",

--- a/lib/statesController.js
+++ b/lib/statesController.js
@@ -72,6 +72,12 @@ class StatesController {
                         }
                     }
                     // Is not an action
+                    // check if its a motion sensor (occupancy state) and if configuration is set to update state every time
+                    // if yes, use setStateSafelyAsync instead of setStateChangedSafelyAsync
+                    else if(this.adapter.config.allwaysUpdateOccupancyState === true && state.id === 'occupancy' && value === true) {
+                        await this.setStateSafelyAsync(stateName, value);
+                    }
+                    // end section for motion sensor update
                     else {
                         if (state.getter) {
                             await this.setStateChangedSafelyAsync(stateName, state.getter(messageObj.payload));


### PR DESCRIPTION
Enables to the update of occupancy state, even if it's true already.

Added configuration dialog to enable and disable this feature.