### PR TITLE
Update package.json - require node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/arteck/ioBroker.zigbee2mqtt.git"
   },
   "engines": {
-    "node": ">= 16"
+    "node": ">= 18"
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.6",


### PR DESCRIPTION
As node 16 is EOL and no more tests are executed against node 16 this adapter should require node 18 minimum with next non-patch release unless you have a very special requirement to support node 16 still