### PR TITLE
chore(translation): fix spelling error

### DIFF
--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -46,7 +46,7 @@
     "Time of the automatic check": "Zeitpunkt der automatischen Prüfung",
     "More information": "Mehr Informationen",
     "Expert Settings. Please only use if you know what you're doing": "Expert Einstellungen. Bitte nur verwenden, wenn Du weisst was du machst",
-  	"Allways update state for occupancy when message arrives from zigbee2mqtt server (Only for true state). Increases load on ioBroker System" : "Aktualisiert immer den Status für die Bewegung, wenn eine Nachricht vom zigbee2mqtt-Server eintrifft (nur bei true). Erhöht die Last auf dem ioBroker",
-    "Allways update available state when message included last_seen status": "Aktualisiert immer den available Status, wenn die Nachricht last_seen Status enthält"
+  	"Always update state for occupancy when message arrives from zigbee2mqtt server (Only for true state). Increases load on ioBroker System" : "Aktualisiert immer den Status für die Bewegung, wenn eine Nachricht vom zigbee2mqtt-Server eintrifft (nur bei true). Erhöht die Last auf dem ioBroker",
+    "Always update available state when message included last_seen status": "Aktualisiert immer den available Status, wenn die Nachricht last_seen Status enthält"
 
 }

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -46,6 +46,6 @@
 	"Time of the automatic check": "Time of the automatic check",
 	"More information": "More information",
 	"Expert Settings. Please only use if you know what you're doing": "Expert Settings. Please only use if you know what you're doing",
-	"Allways update state for occupancy when message arrives from zigbee2mqtt server (Only for true state). Increases load on ioBroker System" : "Allways update state for occupancy when message arrives from zigbee2mqtt server (Only for true state). Increases load on ioBroker System",
-	"Allways update available state when message included last_seen status": "Allways update available state when message included last_seen status"
+	"Always update state for occupancy when message arrives from zigbee2mqtt server (Only for true state). Increases load on ioBroker System" : "Always update state for occupancy when message arrives from zigbee2mqtt server (Only for true state). Increases load on ioBroker System",
+	"Always update available state when message included last_seen status": "Always update available state when message included last_seen status"
 }

--- a/admin/i18n/fr/translations.json
+++ b/admin/i18n/fr/translations.json
@@ -45,5 +45,5 @@
     "With which log level should a negative search be logged?": "Avec quel niveau de journalisation une recherche négative doit-elle être enregistrée ?",
     "Time of the automatic check": "Heure du contrôle automatique",
     "More information": "Plus d'information",
-    "Allways update available state when message included last_seen status": "Mettre à jour l'état disponible lorsque le message inclut le statut last_seen"
+    "Always update available state when message included last_seen status": "Mettre à jour l'état disponible lorsque le message inclut le statut last_seen"
 }

--- a/admin/i18n/it/translations.json
+++ b/admin/i18n/it/translations.json
@@ -45,5 +45,5 @@
     "With which log level should a negative search be logged?": "Con quale livello di registro deve essere registrata una ricerca negativa?",
     "Time of the automatic check": "Orario del controllo automatico",
     "More information": "Maggiori informazioni",
-    "Allways update available state when message included last_seen status": "Aggiorna sempre lo stato disponibile quando il messaggio include lo stato last_seen"
+    "Always update available state when message included last_seen status": "Aggiorna sempre lo stato disponibile quando il messaggio include lo stato last_seen"
 }

--- a/admin/i18n/nl/translations.json
+++ b/admin/i18n/nl/translations.json
@@ -45,5 +45,5 @@
     "With which log level should a negative search be logged?": "Met welk logniveau moet een negatieve zoekopdracht worden geregistreerd?",
     "Time of the automatic check": "Tijdstip van de automatische controle",
     "More information": "Meer informatie",
-    "Allways update available state when message included last_seen status": "Altijd de beschikbare status bijwerken wanneer het bericht de last_seen-status bevat"
+    "Always update available state when message included last_seen status": "Altijd de beschikbare status bijwerken wanneer het bericht de last_seen-status bevat"
 }

--- a/admin/i18n/pl/translations.json
+++ b/admin/i18n/pl/translations.json
@@ -45,5 +45,5 @@
     "With which log level should a negative search be logged?": "Na jakim poziomie rejestrowania należy rejestrować wyszukiwanie wykluczające?",
     "Time of the automatic check": "Czas automatycznego sprawdzenia",
     "More information": "Więcej informacji",
-    "Allways update available state when message included last_seen status": "Zawsze aktualizuj available stan, gdy wiadomość zawiera status last_seen"
+    "Always update available state when message included last_seen status": "Zawsze aktualizuj available stan, gdy wiadomość zawiera status last_seen"
 }

--- a/admin/i18n/pt/translations.json
+++ b/admin/i18n/pt/translations.json
@@ -45,5 +45,5 @@
     "With which log level should a negative search be logged?": "Com qual nível de log uma pesquisa negativa deve ser registrada?",
     "Time of the automatic check": "Hora da verificação automática",
     "More information": "Mais Informações",
-    "Allways update available state when message included last_seen status": "Sempre atualize o estado disponível quando a mensagem incluir o status last_seen"
+    "Always update available state when message included last_seen status": "Sempre atualize o estado disponível quando a mensagem incluir o status last_seen"
 }

--- a/admin/i18n/ru/translations.json
+++ b/admin/i18n/ru/translations.json
@@ -45,5 +45,5 @@
     "With which log level should a negative search be logged?": "На каком уровне журнала следует регистрировать отрицательный поиск?",
     "Time of the automatic check": "Время автоматической проверки",
     "More information": "Больше информации",
-    "Allways update available state when message included last_seen status": "Всегда обновляйте доступное состояние, когда сообщение включает статус last_seen"
+    "Always update available state when message included last_seen status": "Всегда обновляйте доступное состояние, когда сообщение включает статус last_seen"
 }

--- a/admin/i18n/uk/translations.json
+++ b/admin/i18n/uk/translations.json
@@ -45,5 +45,5 @@
     "With which log level should a negative search be logged?": "На якому рівні журналу слід реєструвати негативний пошук?",
     "Time of the automatic check": "Час автоматичної перевірки",
     "More information": "Більше інформації",
-    "Allways update available state when message included last_seen status": "Завжди оновлюйте доступний стан, коли повідомлення містить статус last_seen"
+    "Always update available state when message included last_seen status": "Завжди оновлюйте доступний стан, коли повідомлення містить статус last_seen"
 }

--- a/admin/i18n/zh-cn/translations.json
+++ b/admin/i18n/zh-cn/translations.json
@@ -46,6 +46,6 @@
   "Time of the automatic check": "自动检查时间",
   "More information": "更多信息",
   "Expert Settings. Please only use if you know what you're doing": "专家设置。请仅在您清楚操作的情况下使用",
-  "Allways update state for occupancy when message arrives from zigbee2mqtt server (Only for true state). Increases load on ioBroker System": "当来自 zigbee2mqtt 服务器的消息到达时始终更新占用状态（仅限为 true 的状态）。会增加 ioBroker 系统负载",
-  "Allways update available state when message included last_seen status": "当消息包含 last_seen 状态时始终更新可用状态"
+  "Always update state for occupancy when message arrives from zigbee2mqtt server (Only for true state). Increases load on ioBroker System": "当来自 zigbee2mqtt 服务器的消息到达时始终更新占用状态（仅限为 true 的状态）。会增加 ioBroker 系统负载",
+  "Always update available state when message included last_seen status": "当消息包含 last_seen 状态时始终更新可用状态"
 }

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -532,7 +532,7 @@
 
         "allwaysUpdateOccupancyState": {
           "type": "checkbox",
-          "label": "Allways update state for occupancy when message arrives from zigbee2mqtt server (Only for true state). Increases load on ioBroker System",
+          "label": "Always update state for occupancy when message arrives from zigbee2mqtt server (Only for true state). Increases load on ioBroker System",
           "xs": 12,
           "sm": 12,
           "md": 12,
@@ -542,7 +542,7 @@
         },
         "allwaysUpdateAvailableState": {
           "type": "checkbox",
-          "label": "Allways update available state when message included last_seen status",
+          "label": "Always update available state when message included last_seen status",
           "xs": 12,
           "sm": 12,
           "md": 12,


### PR DESCRIPTION
I have corrected a spelling error in the UI text and the respective translations. The name of the config variable is unchanged.