### PR TITLE
Prefer reported illuminance_raw value

### DIFF
--- a/lib/states.js
+++ b/lib/states.js
@@ -418,7 +418,7 @@ const states = {
         unit: '',
         getter: (payload) => {
             // Wenn illuminance_raw bereits im Payload → illuminance_raw_direct setzt ihn direkt
-            if (payload.illuminance_raw != null) { return undefined; }
+            if (payload.illuminance_raw != null) { return Number(payload.illuminance_raw); }
             const lux = payload.illuminance;
             if (lux == null) { return undefined; }
             if (lux <= 0) { return 0; }


### PR DESCRIPTION
This fixes illuminance_raw not updating when Zigbee2MQTT sends both illuminance and illuminance_raw. The reported RAW value is now used when available. If it is missing, the value is still calculated from illuminance as before. Tested with a Tuya TS0222_solar_light; the ioBroker RAW state now matches the Zigbee2MQTT payload.